### PR TITLE
chore(deps): Update hosted-git-info, ini, lodash and ssri dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,11 @@
 				"concurrently": "^6.1.0",
 				"cross-env": "^7.0.3",
 				"electron": "^12.0.7",
-				"electron-builder": "22.11",
+				"electron-builder": "^22.11.1",
 				"electron-devtools-installer": "^3.2.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-prettier": "^3.4.0",
-				"prettier": "^2.2.1",
+				"prettier": "2.3.0",
 				"react": "^17.0.2",
 				"react-dom": "^17.0.2",
 				"react-scripts": "4.0.3",
@@ -6407,12 +6407,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/concurrently/node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
-		},
 		"node_modules/concurrently/node_modules/string-width": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -11074,9 +11068,9 @@
 			}
 		},
 		"node_modules/hosted-git-info": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true
 		},
 		"node_modules/hpack.js": {
@@ -11726,13 +11720,10 @@
 			"dev": true
 		},
 		"node_modules/ini": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true
 		},
 		"node_modules/internal-ip": {
 			"version": "4.3.0",
@@ -14418,9 +14409,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.20",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
 		"node_modules/lodash._reinterpolate": {
@@ -17488,9 +17479,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+			"integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
 			"dev": true,
 			"bin": {
 				"prettier": "bin-prettier.js"
@@ -22340,12 +22331,6 @@
 				"node": ">=8.9.0"
 			}
 		},
-		"node_modules/wait-on/node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
-		},
 		"node_modules/walker": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
@@ -23540,9 +23525,9 @@
 			}
 		},
 		"node_modules/webpack/node_modules/ssri": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+			"integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
 			"dev": true,
 			"dependencies": {
 				"figgy-pudding": "^3.5.1"
@@ -29813,12 +29798,6 @@
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
 				},
-				"lodash": {
-					"version": "4.17.21",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-					"dev": true
-				},
 				"string-width": {
 					"version": "4.2.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -31195,9 +31174,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "14.14.44",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.44.tgz",
-					"integrity": "sha512-+gaugz6Oce6ZInfI/tK4Pq5wIIkJMEJUu92RB3Eu93mtj4wjjjz9EB5mLp5s1pSsLXdC/CPut/xF20ZzAQJbTA==",
+					"version": "14.14.43",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.43.tgz",
+					"integrity": "sha512-3pwDJjp1PWacPTpH0LcfhgjvurQvrZFBrC6xxjaUEZ7ifUtT32jtjPxEMMblpqd2Mvx+k8haqQJLQxolyGN/cQ==",
 					"dev": true
 				}
 			}
@@ -33696,9 +33675,9 @@
 			"dev": true
 		},
 		"hosted-git-info": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true
 		},
 		"hpack.js": {
@@ -34245,9 +34224,9 @@
 			"dev": true
 		},
 		"ini": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"dev": true
 		},
 		"internal-ip": {
@@ -36421,9 +36400,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.20",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
 		"lodash._reinterpolate": {
@@ -43087,14 +43066,6 @@
 				"lodash": "^4.17.21",
 				"minimist": "^1.2.5",
 				"rxjs": "^6.6.3"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.21",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-					"dev": true
-				}
 			}
 		},
 		"walker": {
@@ -43597,9 +43568,9 @@
 					}
 				},
 				"ssri": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-					"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+					"integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
 					"dev": true,
 					"requires": {
 						"figgy-pudding": "^3.5.1"


### PR DESCRIPTION
```
# npm audit report

hosted-git-info  <2.8.9 || >=3.0.0 <3.0.8
Severity: moderate
Regular Expression Denial of Service - https://npmjs.com/advisories/1677
fix available via `npm audit fix`
node_modules/hosted-git-info

ini  <1.3.6
Prototype Pollution - https://npmjs.com/advisories/1589
fix available via `npm audit fix`
node_modules/ini

lodash  <4.17.21
Severity: high
Command Injection - https://npmjs.com/advisories/1673
fix available via `npm audit fix`
node_modules/lodash

ssri  5.2.2 - 6.0.1 || 7.0.0 - 8.0.0
Severity: moderate
Regular Expression Denial of Service - https://npmjs.com/advisories/565
fix available via `npm audit fix`
node_modules/webpack/node_modules/ssri

4 vulnerabilities (1 low, 2 moderate, 1 high)
```